### PR TITLE
Fix syntax of parameters of mission build batch files

### DIFF
--- a/BuildFiles/Build_mission_Altis.bat
+++ b/BuildFiles/Build_mission_Altis.bat
@@ -15,38 +15,38 @@ set "buildpath=C:\YourBuildPathHere"
 ::set sek=%time:~6,2%
 
 set "mapname=Altis"
-set "missionfloder=VIO-BECTI.%mapname%"
-echo aktuelle Mission wird erstellt unter: "%buildpath%\%missionfloder%"
+set "missionfolder=VIO-BECTI.%mapname%"
+echo aktuelle Mission wird erstellt unter: "%buildpath%\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy Rsc files
-xcopy "%gitpath%\VIO-BECTI.Map_name\Rsc\Pictures" "%buildpath%\%missionfloder%\Rsc\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\Rsc\Sounds" "%buildpath%\%missionfloder%\Rsc\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Debriefing.hpp" "%buildpath%\%missionfloder%\Rsc\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Dialogs.hpp" "%buildpath%\%missionfloder%\Rsc\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Game.hpp" "%buildpath%\%missionfloder%\Rsc\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Notifications.hpp" "%buildpath%\%missionfloder%\Rsc\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Parameters_%mapname%.hpp" "%buildpath%\%missionfloder%\Rsc\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Resources.hpp" "%buildpath%\%missionfloder%\Rsc\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Sounds.hpp" "%buildpath%\%missionfloder%\Rsc\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Styles.hpp" "%buildpath%\%missionfloder%\Rsc\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Titles.hpp" "%buildpath%\%missionfloder%\Rsc\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\Rsc\Pictures" "%buildpath%\%missionfolder%\Rsc\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Rsc\Sounds" "%buildpath%\%missionfolder%\Rsc\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Debriefing.hpp" "%buildpath%\%missionfolder%\Rsc\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Dialogs.hpp" "%buildpath%\%missionfolder%\Rsc\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Game.hpp" "%buildpath%\%missionfolder%\Rsc\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Notifications.hpp" "%buildpath%\%missionfolder%\Rsc\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Parameters_%mapname%.hpp" "%buildpath%\%missionfolder%\Rsc\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Resources.hpp" "%buildpath%\%missionfolder%\Rsc\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Sounds.hpp" "%buildpath%\%missionfolder%\Rsc\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Styles.hpp" "%buildpath%\%missionfolder%\Rsc\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Titles.hpp" "%buildpath%\%missionfolder%\Rsc\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"
 
-start MakePbo "%buildpath%\%missionfloder%"
+start MakePbo "%buildpath%\%missionfolder%"

--- a/BuildFiles/Build_mission_Altis.bat
+++ b/BuildFiles/Build_mission_Altis.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.Altis Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:\YourPathHere"
+set "buildpath=C:\YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,25 +14,25 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="Altis"
-set missionfloder="VIO-BECTI.%mapname%"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=Altis"
+set "missionfloder=VIO-BECTI.%mapname%"
+echo aktuelle Mission wird erstellt unter: "%buildpath%\%missionfloder%"
 echo copy Client folder
 xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
 echo copy Common folder
 xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
-echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters_%mapname%.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+echo copy Rsc files
+xcopy "%gitpath%\VIO-BECTI.Map_name\Rsc\Pictures" "%buildpath%\%missionfloder%\Rsc\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Rsc\Sounds" "%buildpath%\%missionfloder%\Rsc\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Debriefing.hpp" "%buildpath%\%missionfloder%\Rsc\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Dialogs.hpp" "%buildpath%\%missionfloder%\Rsc\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Game.hpp" "%buildpath%\%missionfloder%\Rsc\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Notifications.hpp" "%buildpath%\%missionfloder%\Rsc\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Parameters_%mapname%.hpp" "%buildpath%\%missionfloder%\Rsc\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Resources.hpp" "%buildpath%\%missionfloder%\Rsc\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Sounds.hpp" "%buildpath%\%missionfloder%\Rsc\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Styles.hpp" "%buildpath%\%missionfloder%\Rsc\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\Rsc\Titles.hpp" "%buildpath%\%missionfloder%\Rsc\Titles.hpp"
 echo copy Script files
 copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
@@ -48,3 +48,5 @@ copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionf
 copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
 copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
 copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+
+start MakePbo "%buildpath%\%missionfloder%"

--- a/BuildFiles/Build_mission_Chernarus.bat
+++ b/BuildFiles/Build_mission_Chernarus.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.Chernarus Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:\YourPathHere"
+set "buildpath=C:\YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,37 +14,37 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="Chernarus"
-set missionfloder="VIO-BECTI.%mapname%"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=Chernarus"
+set "missionfolder=VIO-BECTI.%mapname%"
+echo aktuelle Mission wird erstellt unter: "buildpath\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfolder%\RSC\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfolder%\RSC\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfolder%\RSC\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfolder%\RSC\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfolder%\RSC\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfolder%\RSC\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfolder%\RSC\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfolder%\RSC\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfolder%\RSC\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfolder%\RSC\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfolder%\RSC\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%S.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%S.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"

--- a/BuildFiles/Build_mission_ChernarusWinter.bat
+++ b/BuildFiles/Build_mission_ChernarusWinter.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.Chernarus_winter Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:\YourPathHere"
+set "buildpath=C:\YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,37 +14,37 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="Chernarus"
-set missionfloder="VIO-BECTI.%mapname%_winter"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=Chernarus"
+set "missionfolder=VIO-BECTI.%mapname%_winter"
+echo aktuelle Mission wird erstellt unter: "buildpath\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfolder%\RSC\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfolder%\RSC\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfolder%\RSC\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfolder%\RSC\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfolder%\RSC\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfolder%\RSC\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfolder%\RSC\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfolder%\RSC\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfolder%\RSC\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfolder%\RSC\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfolder%\RSC\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%S.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_winter_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%S.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_winter_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"

--- a/BuildFiles/Build_mission_Chernarus_summer.bat
+++ b/BuildFiles/Build_mission_Chernarus_summer.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.Chernarus_summer Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:\YourPathHere"
+set "buildpath=C:\YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,37 +14,37 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="Chernarus"
-set missionfloder="VIO-BECTI.%mapname%_summer"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=Chernarus"
+set "missionfolder=VIO-BECTI.%mapname%_summer"
+echo aktuelle Mission wird erstellt unter: "buildpath\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfolder%\RSC\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfolder%\RSC\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfolder%\RSC\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfolder%\RSC\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfolder%\RSC\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfolder%\RSC\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfolder%\RSC\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfolder%\RSC\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfolder%\RSC\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfolder%\RSC\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfolder%\RSC\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%S.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_summer_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%S.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_summer_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"

--- a/BuildFiles/Build_mission_Enoch.bat
+++ b/BuildFiles/Build_mission_Enoch.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.Enoch Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:\YourPathHere"
+set "buildpath=C:\YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,37 +14,37 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="Enoch"
-set missionfloder="VIO-BECTI.%mapname%"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=Enoch"
+set "missionfolder=VIO-BECTI.%mapname%"
+echo aktuelle Mission wird erstellt unter: "buildpath\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfolder%\RSC\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfolder%\RSC\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfolder%\RSC\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfolder%\RSC\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfolder%\RSC\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfolder%\RSC\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfolder%\RSC\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfolder%\RSC\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfolder%\RSC\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfolder%\RSC\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfolder%\RSC\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"

--- a/BuildFiles/Build_mission_Malden.bat
+++ b/BuildFiles/Build_mission_Malden.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.Malden Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:\YourPathHere"
+set "buildpath=C:\YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,37 +14,37 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="Malden"
-set missionfloder="VIO-BECTI.%mapname%"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=Malden"
+set "missionfolder=VIO-BECTI.%mapname%"
+echo aktuelle Mission wird erstellt unter: "buildpath\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters_%mapname%.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfolder%\RSC\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfolder%\RSC\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfolder%\RSC\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfolder%\RSC\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfolder%\RSC\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfolder%\RSC\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters_%mapname%.hpp" "%buildpath%\%missionfolder%\RSC\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfolder%\RSC\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfolder%\RSC\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfolder%\RSC\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfolder%\RSC\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"

--- a/BuildFiles/Build_mission_Mske.bat
+++ b/BuildFiles/Build_mission_Mske.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.MSKE Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:\YourPathHere"
+set "buildpath=C:\YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,37 +14,37 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="MSKE"
-set missionfloder="VIO-BECTI.%mapname%"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=MSKE"
+set "missionfolder=VIO-BECTI.%mapname%"
+echo aktuelle Mission wird erstellt unter: "buildpath\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfolder%\RSC\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfolder%\RSC\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfolder%\RSC\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfolder%\RSC\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfolder%\RSC\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfolder%\RSC\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfolder%\RSC\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfolder%\RSC\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfolder%\RSC\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfolder%\RSC\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfolder%\RSC\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"

--- a/BuildFiles/Build_mission_Stratis.bat
+++ b/BuildFiles/Build_mission_Stratis.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.Stratis Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:\YourPathHere"
+set "buildpath=C:\YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,37 +14,37 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="Stratis"
-set missionfloder="VIO-BECTI.%mapname%"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=Stratis"
+set "missionfolder=VIO-BECTI.%mapname%"
+echo aktuelle Mission wird erstellt unter: "buildpath\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters_%mapname%.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfolder%\RSC\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfolder%\RSC\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfolder%\RSC\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfolder%\RSC\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfolder%\RSC\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfolder%\RSC\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters_%mapname%.hpp" "%buildpath%\%missionfolder%\RSC\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfolder%\RSC\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfolder%\RSC\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfolder%\RSC\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfolder%\RSC\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"

--- a/BuildFiles/Build_mission_Takistan.bat
+++ b/BuildFiles/Build_mission_Takistan.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.Takistan Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:/YourPathHere"
+set "buildpath=C:/YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,37 +14,37 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="Takistan"
-set missionfloder="VIO-BECTI.%mapname%"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=Takistan"
+set "missionfolder=VIO-BECTI.%mapname%"
+echo aktuelle Mission wird erstellt unter: "buildpath\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfolder%\RSC\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfolder%\RSC\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfolder%\RSC\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfolder%\RSC\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfolder%\RSC\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfolder%\RSC\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfolder%\RSC\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfolder%\RSC\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfolder%\RSC\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfolder%\RSC\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfolder%\RSC\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"

--- a/BuildFiles/Build_mission_Tanoa.bat
+++ b/BuildFiles/Build_mission_Tanoa.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.Tanoa Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:\YourPathHere"
+set "buildpath=C:\YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,37 +14,37 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="Tanoa"
-set missionfloder="VIO-BECTI.%mapname%"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=Tanoa"
+set "missionfolder=VIO-BECTI.%mapname%"
+echo aktuelle Mission wird erstellt unter: "buildpath\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters_%mapname%.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfolder%\RSC\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfolder%\RSC\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfolder%\RSC\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfolder%\RSC\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfolder%\RSC\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfolder%\RSC\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters_%mapname%.hpp" "%buildpath%\%missionfolder%\RSC\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfolder%\RSC\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfolder%\RSC\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfolder%\RSC\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfolder%\RSC\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"

--- a/BuildFiles/Build_mission_WL_Rosche.bat
+++ b/BuildFiles/Build_mission_WL_Rosche.bat
@@ -1,8 +1,8 @@
 @echo off
 title VIO-BECTI.Altis Mission gets created
 
-set gitpath="F:\GitReps\Arma3_CTI"
-set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
+set "gitpath=C:\YourPathHere"
+set "buildpath=C:\YourBuildPathHere"
 ::set buildpath="C:\Users\loewi\Documents\Arma 3 - Other Profiles\dukee\mpmissions\VIO-BECTI"
 
 ::echo Datum wird erstellt
@@ -14,37 +14,37 @@ set buildpath="D:\Tausch\Programmierung\VIO-BECTI\VIO-BECTI"
 ::set min=%time:~3,2%
 ::set sek=%time:~6,2%
 
-set mapname="WL_Rosche"
-set missionfloder="VIO-BECTI.%mapname%"
-echo aktuelle Mission wird erstellt unter: "buildpath\%missionfloder%"
+set "mapname=WL_Rosche"
+set "missionfolder=VIO-BECTI.%mapname%"
+echo aktuelle Mission wird erstellt unter: "buildpath\%missionfolder%"
 echo copy Client folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfloder%\Client" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Client" "%buildpath%\%missionfolder%\Client" /E /Y /I
 echo copy Common folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfloder%\Common" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Common" "%buildpath%\%missionfolder%\Common" /E /Y /I
 echo copy RSC files
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfloder%\RSC\Pictures" /E /Y /I
-xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfloder%\RSC\Sounds" /E /Y /I
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfloder%\RSC\Debriefing.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfloder%\RSC\Dialogs.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfloder%\RSC\Game.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfloder%\RSC\Notifications.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfloder%\RSC\Parameters.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfloder%\RSC\Resources.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfloder%\RSC\Sounds.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfloder%\RSC\Styles.hpp"
-copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfloder%\RSC\Titles.hpp"
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Pictures" "%buildpath%\%missionfolder%\RSC\Pictures" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds" "%buildpath%\%missionfolder%\RSC\Sounds" /E /Y /I
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Debriefing.hpp" "%buildpath%\%missionfolder%\RSC\Debriefing.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Dialogs.hpp" "%buildpath%\%missionfolder%\RSC\Dialogs.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Game.hpp" "%buildpath%\%missionfolder%\RSC\Game.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Notifications.hpp" "%buildpath%\%missionfolder%\RSC\Notifications.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Parameters.hpp" "%buildpath%\%missionfolder%\RSC\Parameters.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Resources.hpp" "%buildpath%\%missionfolder%\RSC\Resources.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Sounds.hpp" "%buildpath%\%missionfolder%\RSC\Sounds.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Styles.hpp" "%buildpath%\%missionfolder%\RSC\Styles.hpp"
+copy "%gitpath%\VIO-BECTI.Map_name\RSC\Titles.hpp" "%buildpath%\%missionfolder%\RSC\Titles.hpp"
 echo copy Script files
-copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfloder%\\Scripts\nre_earplugs.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\\Scripts\nre_earplugs.sqf" "%buildpath%\%missionfolder%\\Scripts\nre_earplugs.sqf"
 echo copy Server folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfloder%\Server" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\Server" "%buildpath%\%missionfolder%\Server" /E /Y /I
 echo copy VAM folder
-xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfloder%\VAM_GUI" /E /Y /I
+xcopy "%gitpath%\VIO-BECTI.Map_name\VAM_GUI" "%buildpath%\%missionfolder%\VAM_GUI" /E /Y /I
 echo copy main files
-copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfloder%\briefing.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfloder%\debug_diag.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfloder%\description.ext"
-copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfloder%\init.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfloder%\mission.sqm"
-copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfloder%\VIO_BECTI.jpg"
-copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfloder%\WFpostprocess.sqf"
-copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfloder%\stringtable.xml"
+copy "%gitpath%\VIO-BECTI.Map_name\briefing.sqf" "%buildpath%\%missionfolder%\briefing.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\debug_diag.sqf" "%buildpath%\%missionfolder%\debug_diag.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\description.ext" "%buildpath%\%missionfolder%\description.ext"
+copy "%gitpath%\VIO-BECTI.Map_name\init.sqf" "%buildpath%\%missionfolder%\init.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\mission_%mapname%.sqm" "%buildpath%\%missionfolder%\mission.sqm"
+copy "%gitpath%\Vanilla-BECTI-Thumpnails\VanillaCTI_%mapname%_small.jpg" "%buildpath%\%missionfolder%\VIO_BECTI.jpg"
+copy "%gitpath%\VIO-BECTI.Map_name\WFpostprocess.sqf" "%buildpath%\%missionfolder%\WFpostprocess.sqf"
+copy "%gitpath%\VIO-BECTI.Map_name\stringtable.xml" "%buildpath%\%missionfolder%\stringtable.xml"


### PR DESCRIPTION
The build batch files had parentheses in slightly wrong position in the parameters causing the build files not to work. The parentheses have been moved to correct positions.

Additionally, small variable name typo (that might have caused annoying bugs later) has been fixed.